### PR TITLE
Fix special but non-ASCII characters causing songs to be filtered

### DIFF
--- a/scripts/apple-music-utils.js
+++ b/scripts/apple-music-utils.js
@@ -131,8 +131,8 @@ function convertTrackToSong(track) {
  */
 function isEnglishOnly(str) {
   if (!str) return false;
-  const nonEnglishPattern = /[^\x00-\x7F]/;
-  return !nonEnglishPattern.test(str);
+  const hasAsianCharacter = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f\uac00-\ud7af]/;
+  return !hasAsianCharacter.test(str);
 }
 
 /**


### PR DESCRIPTION
# 🎵 What's this PR about?

First, thank you for making this game! It's now an essential part of my daily routine lol

Noticed some songs weren't present, likely due to being filtered by the `isEnglishOnly()` function, e.g. LE SSERAFIM - Eve, Psyche & The Bluebeard’s wife and NMIXX - Soñar (Breaker). I don't have an Apple Music token to test full integration but I checked the regex and that appears to work.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 🎨 UI changes
- [x] 🎤 New artist/songs
- [ ] 📚 Documentation

## What changed?
- Changed `isEnglishOnly()` to be an allowlist for Asian characters

## Screenshots/videos (if UI changes)
<!-- Before/after pics/videos if you changed how things look -->

## Quick checklist
- [ ] Tested it works
- [ ] No console errors

---
Thanks! 💜
