### PR TITLE
Submit top song when hitting enter

### DIFF
--- a/src/components/game/GuessInput.tsx
+++ b/src/components/game/GuessInput.tsx
@@ -127,15 +127,15 @@ export default function GuessInput({
         break;
       case 'Enter':
         e.preventDefault();
-        if (selectedIndex >= 0 && selectedIndex < filteredSongs.length) {
-          const selectedSong = filteredSongs[selectedIndex];
-          setGuess(selectedSong.name);
+        const index = selectedIndex === -1 && filteredSongs.length > 0 ? 0 : selectedIndex;
+        if (index >= 0 && index < filteredSongs.length) {
+          const selectedSong = filteredSongs[index];
           setShowDropdown(false);
           onSubmit(selectedSong.name);
         } else if (guess.trim()) {
           onSubmit(guess.trim());
-          setGuess('');
         }
+        setGuess('');
         break;
       case 'Escape':
         setShowDropdown(false);


### PR DESCRIPTION
# 🎵 What's this PR about?

I've had too many accidental erroneous guesses from hitting enter to submit but it would submit my raw guess. This defaults to sending the top guess in the list. I think a more complete solution would prevent guesses with no matches from being submitted but that'd likely need an error UI to be built. Preventing duplicate guesses would be good too imo.

Also fixed a bug where entering a selected item wouldn't clear the guess.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature  
- [x] 🎨 UI changes
- [ ] 🎤 New artist/songs
- [ ] 📚 Documentation

## What changed?
- Hitting enter with no selected song will send the top song in the filtered list
- Fixed entering selected guesses not clearing the guess from the box

## Screenshots/videos (if UI changes)
<!-- Before/after pics/videos if you changed how things look -->

https://github.com/user-attachments/assets/6a8abf14-5f7f-440e-94ae-d44319714ae6



## Quick checklist
- [x] Tested it works
- [x] No console errors

---
Thanks! 💜
